### PR TITLE
use version 1.4 of php-odm only as 2.0 does not exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Symfony package repository to install dbal implementation of doctrine/phpcr-bundle.",
   "type": "symfony-bundle",
   "require": {
-    "doctrine/phpcr-bundle": "^2.0",
+    "doctrine/phpcr-bundle": "^1.3 || ^2.0",
     "jackalope/jackalope-doctrine-dbal": "^1.3",
     "doctrine/doctrine-cache-bundle": "^1.3",
     "doctrine/phpcr-odm": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "doctrine/phpcr-bundle": "^2.0",
     "jackalope/jackalope-doctrine-dbal": "^1.3",
     "doctrine/doctrine-cache-bundle": "^1.3",
-    "doctrine/phpcr-odm": "^2.0",
-    "doctrine/orm": "2.7.x-dev",
+    "doctrine/phpcr-odm": "^1.4",
+    "doctrine/orm": "^2.7",
     "doctrine/doctrine-bundle": "^1.8"
   },
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "jackalope/jackalope-doctrine-dbal": "^1.3",
     "doctrine/doctrine-cache-bundle": "^1.3",
     "doctrine/phpcr-odm": "^1.4",
-    "doctrine/orm": "^2.7",
+    "doctrine/orm": "^2.5",
     "doctrine/doctrine-bundle": "^1.8"
   },
   "license": "MIT",


### PR DESCRIPTION
When doing first usage i relized that i made a mistake with versions.